### PR TITLE
feat: Add Sunmi V2 print functionality for counter value

### DIFF
--- a/flutter_application_1/android/app/src/main/AndroidManifest.xml
+++ b/flutter_application_1/android/app/src/main/AndroidManifest.xml
@@ -42,4 +42,10 @@
             <data android:mimeType="text/plain"/>
         </intent>
     </queries>
+
+    <!-- Hypothetical permission for Sunmi Printer Access -->
+    <!-- The actual permissions required will depend on the specific plugin and Sunmi SDK version -->
+    <uses-permission android:name="com.sunmi.perm.COMM_DATA" />
+    <!-- Add other permissions like Bluetooth, Network, etc., if required by the plugin -->
+
 </manifest>

--- a/flutter_application_1/lib/main.dart
+++ b/flutter_application_1/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:sunmi_printer_flutter/sunmi_printer_flutter.dart'; // Hypothetical plugin import
 
 void main() {
   runApp(const MyApp());
@@ -71,6 +72,37 @@ class _MyHomePageState extends State<MyHomePage> {
     });
   }
 
+  Future<void> _printCounterValue() async {
+    try {
+      // Initialize printer (assuming this is needed and is idempotent or handled by plugin)
+      // await SunmiPrinter.initialize(); // Specifics depend on plugin API
+
+      // Prepare text to print
+      String textToPrint = 'Current Counter: $_counter';
+
+      // Print the text - assuming a simple text printing method
+      // The actual API might differ (e.g., require specific styling objects)
+      await SunmiPrinter.printText(textToPrint);
+      await SunmiPrinter.lineFeed(3); // Add some empty lines for spacing
+      await SunmiPrinter.cutPaper(); // Cut the paper
+
+      // Optionally, show a success message to the user (e.g., via a SnackBar)
+      if (mounted) { // Check if the widget is still in the tree
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Sent to printer!')),
+        );
+      }
+    } catch (e) {
+      // Handle printing errors (e.g., printer not connected, out of paper)
+      print('Error printing: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Printing failed: $e')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // This method is rerun every time setState is called, for instance as done
@@ -121,7 +153,12 @@ class _MyHomePageState extends State<MyHomePage> {
                   onPressed: () => _changeCounter(false), // Decrement
                   child: const Icon(Icons.remove),
                 ),
-                const SizedBox(width: 20), // Spacer between buttons
+                const SizedBox(width: 10), // Spacer
+                ElevatedButton(
+                  onPressed: _printCounterValue,
+                  child: const Text('Print'),
+                ),
+                const SizedBox(width: 10), // Spacer
                 ElevatedButton(
                   onPressed: () => _changeCounter(true), // Increment
                   child: const Icon(Icons.add),

--- a/flutter_application_1/pubspec.yaml
+++ b/flutter_application_1/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  sunmi_printer_flutter: ^1.0.0 # Hypothetical Sunmi printer plugin
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Added a 'Print' button to the UI between the increment and decrement buttons.
- Integrated a hypothetical Flutter plugin (`sunmi_printer_flutter`) to handle printing:
  - Added plugin to `pubspec.yaml`.
  - Implemented `_printCounterValue` method in `main.dart` to send the current counter value to the printer using the plugin's API (printText, lineFeed, cutPaper).
  - Included error handling (try-catch) and user feedback (SnackBars) for the printing process.
- Added a placeholder permission (`com.sunmi.perm.COMM_DATA`) to `AndroidManifest.xml` as an example of native configuration.

Note: The `sunmi_printer_flutter` plugin and its API are hypothetical. You will need to replace this with a real Sunmi printer plugin and its actual API, and ensure all required native configurations (permissions, etc.) are correctly set up according to the chosen plugin's documentation.